### PR TITLE
feature: Initialize Route53 Profiles module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will automatically be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# terraform-aws-mcaf-route53-profile-sharing
-Terraform module to create, manage, and share Route53 Profiles
+# terraform-aws-mcaf-route53-profiles
+Terraform module to:
+
+- create [Route53 Profiles](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/profiles.html)
+- associate Route53 resources to the Profile
+
+# Usage
+
+To create a Route53 Profile and associated resources, define the following input variables:
+
+1. `name` - This will be the name of the Route53 Profile
+2. `associated_resources` - This maps association names to resource ARNs that will be associated with the Route53 Profile
+
+```hcl
+module "route53_profile" {
+  source = "../../"
+
+  name = "profile-1"
+  associated_resources = {
+    resolver-rule-1 = "arn:aws:route53resolver:eu-central-1:123456789012:resolver-rule/rslvr-rr-01a2bcd3456e7890f"
+    resolver-rule-2 = "arn:aws:route53resolver:eu-central-1:123456789012:resolver-rule/rslvr-rr-02a2bcd3456e7890f"
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -22,3 +22,44 @@ module "route53_profile" {
   }
 }
 ```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53profiles_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53profiles_profile) | resource |
+| [aws_route53profiles_resource_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53profiles_resource_association) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_associated_resources"></a> [associated\_resources](#input\_associated\_resources) | A map of Association Names to Resource ARNs to associate with the AWS Route53 Profile | `map(string)` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the Route53 Profile | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_profile_arn"></a> [profile\_arn](#output\_profile\_arn) | n/a |
+| <a name="output_profile_id"></a> [profile\_id](#output\_profile\_id) | n/a |
+| <a name="output_profile_name"></a> [profile\_name](#output\_profile\_name) | n/a |
+<!-- END_TF_DOCS -->

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,0 +1,9 @@
+module "route53_profile" {
+  source = "../../"
+
+  name = "profile-1"
+  associated_resources = {
+    resolver-rule-1 = "arn:aws:route53resolver:eu-central-1:123456789012:resolver-rule/rslvr-rr-01a2bcd3456e7890f"
+    resolver-rule-2 = "arn:aws:route53resolver:eu-central-1:123456789012:resolver-rule/rslvr-rr-02a2bcd3456e7890f"
+  }
+}

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.82"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,11 @@
+resource "aws_route53profiles_profile" "default" {
+  name = var.name
+}
+
+resource "aws_route53profiles_resource_association" "default" {
+  for_each = var.associated_resources
+
+  name         = each.key
+  profile_id   = aws_route53profiles_profile.default.id
+  resource_arn = each.value
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,11 @@
+output "profile_arn" {
+  value = aws_route53profiles_profile.default.arn
+}
+
+output "profile_name" {
+  value = aws_route53profiles_profile.default.name
+}
+
+output "profile_id" {
+  value = aws_route53profiles_profile.default.id
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.82"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  type        = string
+  description = "Name of the Route53 Profile"
+}
+
+variable "associated_resources" {
+  type        = map(string)
+  description = "A map of Association Names to Resource ARNs to associate with the AWS Route53 Profile"
+}


### PR DESCRIPTION
## :hammer_and_wrench: Summary

This PR will initialize the Route53 Profiles Module which can be used to create and manage Route53 Profiles and their resource associations.

## :rocket: Motivation

This module streamlines creation and management of Route53 Profiles and resources associations.

## :pencil: Additional Information

AWS Documentation: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/profiles.html
