### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ module "route53_profile" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ module "route53_profile" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 
@@ -55,6 +55,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_associated_resources"></a> [associated\_resources](#input\_associated\_resources) | A map of Association Names to Resource ARNs to associate with the AWS Route53 Profile | `map(string)` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the Route53 Profile | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 
 ## Outputs
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,9 @@
+# Upgrading Notes
+
+This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
+
+## Upgrading to v2.0.0
+
+### Key Changes
+
+- This module now requires a minimum AWS provider version of 6.0 to support the `region` parameter. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.82"
+      version = "~> 6.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,13 @@
 resource "aws_route53profiles_profile" "default" {
-  name   = var.name
   region = var.region
+  name   = var.name
 }
 
 resource "aws_route53profiles_resource_association" "default" {
   for_each = var.associated_resources
 
+  region       = var.region
   name         = each.key
   profile_id   = aws_route53profiles_profile.default.id
-  region       = var.region
   resource_arn = each.value
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 resource "aws_route53profiles_profile" "default" {
-  name = var.name
+  name   = var.name
+  region = var.region
 }
 
 resource "aws_route53profiles_resource_association" "default" {
@@ -7,5 +8,6 @@ resource "aws_route53profiles_resource_association" "default" {
 
   name         = each.key
   profile_id   = aws_route53profiles_profile.default.id
+  region       = var.region
   resource_arn = each.value
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.82"
+      version = "~> 6.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,9 @@ variable "associated_resources" {
   type        = map(string)
   description = "A map of Association Names to Resource ARNs to associate with the AWS Route53 Profile"
 }
+
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
+}


### PR DESCRIPTION
⚠️  This introduces a breaking change as it requires at least v6 of the AWS provider. ⚠️

## :hammer_and_wrench: Summary

Region configuration improvements:

- Added a new `region` variable in `variables.tf` to allow users to specify the AWS region for the Route53 profile and related resources. If omitted, the default provider region is used.
- Updated all resources to accept and use the region variable. This ensures consistent resource creation in the specified region.

## :rocket: Motivation

Adding `var.region` removes the need to instantiate multiple AWS provider instances for multi-region deployments and ensure compatibility with the latest AWS provider.

## :pencil: Additional Information

- [Terraform AWS Provider Version 6 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade)
